### PR TITLE
modify shipping Fee caculator.

### DIFF
--- a/backend/controllers/orderController.js
+++ b/backend/controllers/orderController.js
@@ -87,6 +87,7 @@ const submitOrder = async (req, res) => {
     // 建立訂單明細
     const orderItems = [];
     let subtotal = 0;
+    let totalQuantity = 0;
     
     for (const cartItem of cartItems) {
       // 從資料庫取得最新產品資訊
@@ -114,10 +115,11 @@ const submitOrder = async (req, res) => {
       
       orderItems.push(orderItem[0]._id);
       subtotal += itemSubtotal;
+      totalQuantity += cartItem.cartQuantity;
     }
     
-    // 固定運費 100 元
-    const shippingFee = 100;
+    // 運費計算：總數量2個以上免運費，否則收費100元
+    const shippingFee = totalQuantity >= 2 ? 0 : 100;
     const totalAmount = subtotal + shippingFee;
     
     // 建立訂單 (使用 session)

--- a/backend/package.json
+++ b/backend/package.json
@@ -13,7 +13,8 @@
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",
     "test:unit": "jest --testMatch='**/*.unit.test.js'",
-    "test:controllers": "jest controllers --testPathPattern=test"
+    "test:controllers": "jest controllers --testPathPattern=test",
+    "build": "npm install"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
This pull request introduces an updated shipping fee calculation in the order submission logic and a minor addition to the npm scripts in `package.json`. The most significant change is that shipping is now free for orders with two or more items, otherwise a fee is charged.

Order processing improvements:
* Updated the shipping fee logic in `submitOrder` so that orders with a total quantity of 2 or more items receive free shipping; otherwise, a 100-unit fee is applied. This involved tracking `totalQuantity` as items are processed. [[1]](diffhunk://#diff-656280b75b89345f51fe077a7f773418a81276d9e1bcd1227002b2eca0524c79R90) [[2]](diffhunk://#diff-656280b75b89345f51fe077a7f773418a81276d9e1bcd1227002b2eca0524c79R118-R122)

Build process:
* Added a `"build"` script to `backend/package.json` that runs `npm install`.