### PR TITLE
Development

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "backend/shared/models"]
+	path = backend/shared/models
+	url = https://github.com/JeterChan/fruit-web-models.git

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,29 +1,27 @@
 # Backend Dockerfile for Node.js Express application
 FROM node:18-alpine
 
-# install git (for cloning models repository)
-RUN apk add --no-cache git
-
 WORKDIR /app
 
 # Copy package files
 COPY package*.json ./
 
-# clone shared models
-RUN git clone https://github.com/JeterChan/fruit-web-models.git shared/models
-
 # Install production dependencies
 RUN npm install --only=production
 
-# Copy source code
+# Copy source code (including submodule)
 COPY . .
+
+# Change ownership of the app directory to the nodejs user
+RUN chown -R backend:nodejs /app
+USER backend
+
+# Expose port 5000
+EXPOSE 5000
 
 # 健康檢查
 HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
   CMD curl -f http://localhost:5000/health || exit 1
-
-# Expose port 5000
-EXPOSE 5000
 
 # Start the application
 CMD ["npm", "start"]


### PR DESCRIPTION
This pull request updates how the backend service integrates shared models by switching from cloning the models repository at build time to using a Git submodule. It also improves Dockerfile practices by adjusting user permissions and cleaning up the build process.

**Integration of shared models:**
* Added a Git submodule for the shared models repository at `backend/shared/models`, replacing the previous approach of cloning the repository during the Docker build. (`.gitmodules`, `backend/shared/models`) [[1]](diffhunk://#diff-fe7afb5c9c916e521401d3fcfb4277d5071798c3baf83baf11d6071742823584R1-R3) [[2]](diffhunk://#diff-30556fddbc9060268c961928db14c591f32fd602b2504bc2365af8d258af5365R1)

**Dockerfile improvements:**
* Removed the installation of `git` and the `git clone` command from the Dockerfile, as the shared models are now included as a submodule. (`backend/Dockerfile`)
* Changed file ownership of the app directory to the `backend` user and switched to running the container as this user, improving security. (`backend/Dockerfile`)
* Moved the health check section for clarity, but its functionality remains unchanged. (`backend/Dockerfile`)